### PR TITLE
Renamed Variables

### DIFF
--- a/src/engine/collision.cpp
+++ b/src/engine/collision.cpp
@@ -6,6 +6,7 @@ void PlayerBlockCollision(sf::Sprite *player_sprite, sf::Sprite &block_sprite,
     float offset = 5;
     float player_width = player_sprite->getGlobalBounds().width;
     float player_height = player_sprite->getGlobalBounds().height;
+
     /* X Axis Collision */
     if (player_sprite->getPosition().y >
             block_sprite.getPosition().y + offset &&
@@ -80,7 +81,7 @@ void PlayerBlockCollision(sf::Sprite *player_sprite, sf::Sprite &block_sprite,
                    player_sprite->getPosition().y >
                        block_sprite.getPosition().y) {
             // bottom collision
-            player_sprite->move(0, motion_speed.accel);
+            player_sprite->move(0, motion_speed.accel * 2);
         }
     }
 
@@ -100,7 +101,7 @@ void PlayerBlockCollision(sf::Sprite *player_sprite, sf::Sprite &block_sprite,
                    player_sprite->getPosition().y >
                        block_sprite.getPosition().y) {
             // bottom collision
-            player_sprite->move(0, motion_speed.accel);
+            player_sprite->move(0, motion_speed.accel * 2);
         }
     }
 
@@ -120,7 +121,7 @@ void PlayerBlockCollision(sf::Sprite *player_sprite, sf::Sprite &block_sprite,
                    player_sprite->getPosition().y >
                        block_sprite.getPosition().y) {
             // bottom collision
-            player_sprite->move(0, motion_speed.accel);
+            player_sprite->move(0, motion_speed.accel * 2);
         }
     }
 }

--- a/src/engine/collision.cpp
+++ b/src/engine/collision.cpp
@@ -1,135 +1,144 @@
 #include "collision.hpp"
 
-void PlayerWallCollision(sf::Sprite *player_sprite, sf::Sprite &wall,
-                         CollisionState *collision_state,
-                         MotionSpeed motion_speed) {
+void PlayerBlockCollision(sf::Sprite *player_sprite, sf::Sprite &block_sprite,
+                          CollisionState *collision_state,
+                          MotionSpeed motion_speed) {
     float offset = 5;
     float player_width = player_sprite->getGlobalBounds().width;
     float player_height = player_sprite->getGlobalBounds().height;
     /* X Axis Collision */
-    if (player_sprite->getPosition().y > wall.getPosition().y + offset &&
+    if (player_sprite->getPosition().y >
+            block_sprite.getPosition().y + offset &&
         player_sprite->getPosition().y <
-            wall.getPosition().y + player_height - offset) {
+            block_sprite.getPosition().y + player_height - offset) {
         if (player_sprite->getPosition().x + player_width >
-                wall.getPosition().x &&
+                block_sprite.getPosition().x &&
             player_sprite->getPosition().x + player_width <
-                wall.getPosition().x + player_width) {
+                block_sprite.getPosition().x + player_width) {
             // left collision
             player_sprite->move(-motion_speed.speed, 0);
         } else if (player_sprite->getPosition().x <
-                       wall.getPosition().x + player_width &&
-                   player_sprite->getPosition().x > wall.getPosition().x) {
+                       block_sprite.getPosition().x + player_width &&
+                   player_sprite->getPosition().x >
+                       block_sprite.getPosition().x) {
             // right collision
             player_sprite->move(motion_speed.speed, 0);
         }
     }
 
     else if (player_sprite->getPosition().y + player_height >
-                 wall.getPosition().y + offset &&
+                 block_sprite.getPosition().y + offset &&
              player_sprite->getPosition().y + player_height <
-                 wall.getPosition().y + player_height - offset) {
+                 block_sprite.getPosition().y + player_height - offset) {
         if (player_sprite->getPosition().x + player_width >
-                wall.getPosition().x &&
+                block_sprite.getPosition().x &&
             player_sprite->getPosition().x + player_width <
-                wall.getPosition().x + player_width) {
+                block_sprite.getPosition().x + player_width) {
             // left collision
             player_sprite->move(-motion_speed.speed, 0);
         } else if (player_sprite->getPosition().x <
-                       wall.getPosition().x + player_width &&
-                   player_sprite->getPosition().x > wall.getPosition().x) {
+                       block_sprite.getPosition().x + player_width &&
+                   player_sprite->getPosition().x >
+                       block_sprite.getPosition().x) {
             // right collision
             player_sprite->move(motion_speed.speed, 0);
         }
     }
 
     else if (player_sprite->getPosition().y + player_height / 2 >
-                 wall.getPosition().y &&
+                 block_sprite.getPosition().y &&
              player_sprite->getPosition().y + player_height / 2 <
-                 wall.getPosition().y + player_height) {
+                 block_sprite.getPosition().y + player_height) {
         if (player_sprite->getPosition().x + player_width >
-                wall.getPosition().x &&
+                block_sprite.getPosition().x &&
             player_sprite->getPosition().x + player_width <
-                wall.getPosition().x + player_width) {
+                block_sprite.getPosition().x + player_width) {
             // left collision
             player_sprite->move(-motion_speed.speed, 0);
         } else if (player_sprite->getPosition().x <
-                       wall.getPosition().x + player_width &&
-                   player_sprite->getPosition().x > wall.getPosition().x) {
+                       block_sprite.getPosition().x + player_width &&
+                   player_sprite->getPosition().x >
+                       block_sprite.getPosition().x) {
             // right collision
             player_sprite->move(motion_speed.speed, 0);
         }
     }
 
     /* Y Axis Collision */
-    if (player_sprite->getPosition().x > wall.getPosition().x &&
-        player_sprite->getPosition().x < wall.getPosition().x + player_width) {
+    if (player_sprite->getPosition().x > block_sprite.getPosition().x &&
+        player_sprite->getPosition().x <
+            block_sprite.getPosition().x + player_width) {
         if (player_sprite->getPosition().y + player_height >
-                wall.getPosition().y &&
+                block_sprite.getPosition().y &&
             player_sprite->getPosition().y + player_height <
-                wall.getPosition().y + player_height) {
+                block_sprite.getPosition().y + player_height) {
             // top collision
             player_sprite->move(0, -motion_speed.accel);
             collision_state->on_the_floor = true;
         } else if (player_sprite->getPosition().y <
-                       wall.getPosition().y + player_height &&
-                   player_sprite->getPosition().y > wall.getPosition().y) {
+                       block_sprite.getPosition().y + player_height &&
+                   player_sprite->getPosition().y >
+                       block_sprite.getPosition().y) {
             // bottom collision
             player_sprite->move(0, motion_speed.accel);
         }
     }
 
     else if (player_sprite->getPosition().x + player_width >
-                 wall.getPosition().x &&
+                 block_sprite.getPosition().x &&
              player_sprite->getPosition().x + player_width <
-                 wall.getPosition().x + player_width) {
+                 block_sprite.getPosition().x + player_width) {
         if (player_sprite->getPosition().y + player_height >
-                wall.getPosition().y &&
+                block_sprite.getPosition().y &&
             player_sprite->getPosition().y + player_height <
-                wall.getPosition().y + player_height) {
+                block_sprite.getPosition().y + player_height) {
             // top collision
             player_sprite->move(0, -motion_speed.accel);
             collision_state->on_the_floor = true;
         } else if (player_sprite->getPosition().y <
-                       wall.getPosition().y + player_height &&
-                   player_sprite->getPosition().y > wall.getPosition().y) {
+                       block_sprite.getPosition().y + player_height &&
+                   player_sprite->getPosition().y >
+                       block_sprite.getPosition().y) {
             // bottom collision
             player_sprite->move(0, motion_speed.accel);
         }
     }
 
     else if (player_sprite->getPosition().x + player_width / 2 >
-                 wall.getPosition().x &&
+                 block_sprite.getPosition().x &&
              player_sprite->getPosition().x + player_width / 2 <
-                 wall.getPosition().x + player_width) {
+                 block_sprite.getPosition().x + player_width) {
         if (player_sprite->getPosition().y + player_height >
-                wall.getPosition().y &&
+                block_sprite.getPosition().y &&
             player_sprite->getPosition().y + player_height <
-                wall.getPosition().y + player_height) {
+                block_sprite.getPosition().y + player_height) {
             // top collision
             player_sprite->move(0, -motion_speed.accel);
             collision_state->on_the_floor = true;
         } else if (player_sprite->getPosition().y <
-                       wall.getPosition().y + player_height &&
-                   player_sprite->getPosition().y > wall.getPosition().y) {
+                       block_sprite.getPosition().y + player_height &&
+                   player_sprite->getPosition().y >
+                       block_sprite.getPosition().y) {
             // bottom collision
             player_sprite->move(0, motion_speed.accel);
         }
     }
 }
 
-void PlayerPlatformCollision(sf::Sprite *player_sprite, sf::Sprite &platform,
+void PlayerPlatformCollision(sf::Sprite *player_sprite,
+                             sf::Sprite &platform_sprite,
                              CollisionState *collision_state, float accel) {
     float player_width = player_sprite->getGlobalBounds().width;
     float player_height = player_sprite->getGlobalBounds().height;
 
     /* Y Axis Collision */
-    if (player_sprite->getPosition().x > platform.getPosition().x &&
+    if (player_sprite->getPosition().x > platform_sprite.getPosition().x &&
         player_sprite->getPosition().x <
-            platform.getPosition().x + player_width) {
+            platform_sprite.getPosition().x + player_width) {
         if (player_sprite->getPosition().y + player_height >
-                platform.getPosition().y &&
+                platform_sprite.getPosition().y &&
             player_sprite->getPosition().y + player_height <
-                platform.getPosition().y + 2 * accel) {
+                platform_sprite.getPosition().y + 2 * accel) {
             // top collision
             player_sprite->move(0, -accel);
             collision_state->on_the_floor = true;
@@ -138,13 +147,13 @@ void PlayerPlatformCollision(sf::Sprite *player_sprite, sf::Sprite &platform,
     }
 
     else if (player_sprite->getPosition().x + player_width >
-                 platform.getPosition().x &&
+                 platform_sprite.getPosition().x &&
              player_sprite->getPosition().x + player_width <
-                 platform.getPosition().x + player_width) {
+                 platform_sprite.getPosition().x + player_width) {
         if (player_sprite->getPosition().y + player_height >
-                platform.getPosition().y &&
+                platform_sprite.getPosition().y &&
             player_sprite->getPosition().y + player_height <
-                platform.getPosition().y + 2 * accel) {
+                platform_sprite.getPosition().y + 2 * accel) {
             // top collision
             player_sprite->move(0, -accel);
             collision_state->on_the_floor = true;
@@ -153,13 +162,13 @@ void PlayerPlatformCollision(sf::Sprite *player_sprite, sf::Sprite &platform,
     }
 
     else if (player_sprite->getPosition().x + player_width / 2 >
-                 platform.getPosition().x &&
+                 platform_sprite.getPosition().x &&
              player_sprite->getPosition().x + player_width / 2 <
-                 platform.getPosition().x + player_width) {
+                 platform_sprite.getPosition().x + player_width) {
         if (player_sprite->getPosition().y + player_height >
-                platform.getPosition().y &&
+                platform_sprite.getPosition().y &&
             player_sprite->getPosition().y + player_height <
-                platform.getPosition().y + 2 * accel) {
+                platform_sprite.getPosition().y + 2 * accel) {
             // top collision
             player_sprite->move(0, -accel);
             collision_state->on_the_floor = true;

--- a/src/engine/collision.hpp
+++ b/src/engine/collision.hpp
@@ -1,8 +1,9 @@
 #include "engine/entities.hpp"
 
-void PlayerWallCollision(sf::Sprite *player_sprite, sf::Sprite &wall,
-                         CollisionState *collision_state,
-                         MotionSpeed motion_speed);
+void PlayerBlockCollision(sf::Sprite *player_sprite, sf::Sprite &block_sprite,
+                          CollisionState *collision_state,
+                          MotionSpeed motion_speed);
 
-void PlayerPlatformCollision(sf::Sprite *player_sprite, sf::Sprite &platform,
+void PlayerPlatformCollision(sf::Sprite *player_sprite,
+                             sf::Sprite &platform_sprite,
                              CollisionState *collision_state, float accel);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,14 +17,14 @@ constexpr unsigned LEVEL_HEIGHT = 500;
 sf::Vector2f PlayerBoundary(sf::Vector2f position, sf::FloatRect global_bounds);
 
 void PlayerSpriteCollisions(sf::Sprite *player,
-                            std::array<sf::Sprite, 45> walls,
-                            std::array<sf::Sprite, 12> platforms,
+                            std::array<sf::Sprite, 45> block_sprites,
+                            std::array<sf::Sprite, 12> platform_sprites,
                             CollisionState *collision_state,
                             MotionSpeed motion_speed);
 
 void DrawAllSprites(sf::RenderWindow &window, sf::Sprite &player,
-                    std::array<sf::Sprite, 45> walls,
-                    std::array<sf::Sprite, 12> platforms);
+                    std::array<sf::Sprite, 45> block_sprites,
+                    std::array<sf::Sprite, 12> platform_sprites);
 
 int main() {
     const float player_speed = 1.25;
@@ -48,95 +48,102 @@ int main() {
 
     player_sprite.setPosition(0, LEVEL_HEIGHT - 250);
 
-    sf::Texture wall_texture;
-    if (!wall_texture.loadFromFile("./assets/tiles/tile1.png")) {
+    sf::Texture block_texture;
+    if (!block_texture.loadFromFile("./assets/tiles/tile1.png")) {
         std::cout << "Unable to load image file" << std::endl;
     }
 
-    sf::Sprite wall;
-    wall.setTexture(wall_texture);
-    wall.scale(sf::Vector2f(25 / wall.getLocalBounds().width,
-                            25 / wall.getLocalBounds().height));
+    sf::Sprite block_sprite;
+    block_sprite.setTexture(block_texture);
+    block_sprite.scale(sf::Vector2f(25 / block_sprite.getLocalBounds().width,
+                                    25 / block_sprite.getLocalBounds().height));
 
     sf::Texture platform_texture;
     if (!platform_texture.loadFromFile("./assets/tiles/tile2.png")) {
         std::cout << "Unable to load image file" << std::endl;
     }
 
-    sf::Sprite platform;
-    platform.setTexture(platform_texture);
-    platform.scale(sf::Vector2f(25 / platform.getLocalBounds().width,
-                                25 / platform.getLocalBounds().height));
+    sf::Sprite platform_sprite;
+    platform_sprite.setTexture(platform_texture);
+    platform_sprite.scale(
+        sf::Vector2f(25 / platform_sprite.getLocalBounds().width,
+                     25 / platform_sprite.getLocalBounds().height));
 
     // Scene Layout
-    std::array<sf::Sprite, 45> walls = {
-        wall, wall, wall, wall, wall, wall, wall, wall, wall, wall, wall, wall,
-        wall, wall, wall, wall, wall, wall, wall, wall, wall, wall, wall, wall,
-        wall, wall, wall, wall, wall, wall, wall, wall, wall, wall, wall, wall,
-        wall, wall, wall, wall, wall, wall, wall, wall, wall};
+    std::array<sf::Sprite, 45> block_sprites = {
+        block_sprite, block_sprite, block_sprite, block_sprite, block_sprite,
+        block_sprite, block_sprite, block_sprite, block_sprite, block_sprite,
+        block_sprite, block_sprite, block_sprite, block_sprite, block_sprite,
+        block_sprite, block_sprite, block_sprite, block_sprite, block_sprite,
+        block_sprite, block_sprite, block_sprite, block_sprite, block_sprite,
+        block_sprite, block_sprite, block_sprite, block_sprite, block_sprite,
+        block_sprite, block_sprite, block_sprite, block_sprite, block_sprite,
+        block_sprite, block_sprite, block_sprite, block_sprite, block_sprite,
+        block_sprite, block_sprite, block_sprite, block_sprite, block_sprite};
 
-    std::array<sf::Sprite, 12> platforms = {
-        platform, platform, platform, platform, platform, platform,
-        platform, platform, platform, platform, platform, platform};
+    std::array<sf::Sprite, 12> platform_sprites = {
+        platform_sprite, platform_sprite, platform_sprite, platform_sprite,
+        platform_sprite, platform_sprite, platform_sprite, platform_sprite,
+        platform_sprite, platform_sprite, platform_sprite, platform_sprite};
 
-    walls[0].setPosition(LEVEL_WIDTH - 25, LEVEL_HEIGHT - 25);
-    walls[1].setPosition(LEVEL_WIDTH - 50, LEVEL_HEIGHT - 25);
-    walls[2].setPosition(LEVEL_WIDTH - 75, LEVEL_HEIGHT - 25);
-    walls[3].setPosition(LEVEL_WIDTH - 100, LEVEL_HEIGHT - 25);
-    walls[4].setPosition(LEVEL_WIDTH - 125, LEVEL_HEIGHT - 25);
-    walls[5].setPosition(LEVEL_WIDTH - 150, LEVEL_HEIGHT - 25);
-    walls[6].setPosition(LEVEL_WIDTH - 175, LEVEL_HEIGHT - 25);
-    walls[7].setPosition(LEVEL_WIDTH - 200, LEVEL_HEIGHT - 25);
-    walls[8].setPosition(LEVEL_WIDTH - 225, LEVEL_HEIGHT - 25);
-    walls[9].setPosition(LEVEL_WIDTH - 250, LEVEL_HEIGHT - 25);
-    walls[10].setPosition(LEVEL_WIDTH - 275, LEVEL_HEIGHT - 25);
-    walls[11].setPosition(LEVEL_WIDTH - 300, LEVEL_HEIGHT - 25);
-    walls[12].setPosition(LEVEL_WIDTH - 325, LEVEL_HEIGHT - 25);
-    walls[13].setPosition(LEVEL_WIDTH - 350, LEVEL_HEIGHT - 25);
-    walls[14].setPosition(LEVEL_WIDTH - 375, LEVEL_HEIGHT - 25);
-    walls[15].setPosition(LEVEL_WIDTH - 400, LEVEL_HEIGHT - 25);
-    walls[16].setPosition(LEVEL_WIDTH - 425, LEVEL_HEIGHT - 25);
-    walls[17].setPosition(LEVEL_WIDTH - 450, LEVEL_HEIGHT - 25);
-    walls[18].setPosition(LEVEL_WIDTH - 475, LEVEL_HEIGHT - 25);
-    walls[19].setPosition(LEVEL_WIDTH - 500, LEVEL_HEIGHT - 25);
-    walls[20].setPosition(LEVEL_WIDTH - 525, LEVEL_HEIGHT - 25);
-    walls[21].setPosition(LEVEL_WIDTH - 550, LEVEL_HEIGHT - 25);
-    walls[22].setPosition(LEVEL_WIDTH - 575, LEVEL_HEIGHT - 25);
-    walls[23].setPosition(LEVEL_WIDTH - 600, LEVEL_HEIGHT - 25);
-    walls[24].setPosition(LEVEL_WIDTH - 625, LEVEL_HEIGHT - 25);
-    walls[25].setPosition(LEVEL_WIDTH - 650, LEVEL_HEIGHT - 25);
-    walls[26].setPosition(LEVEL_WIDTH - 675, LEVEL_HEIGHT - 25);
-    walls[27].setPosition(LEVEL_WIDTH - 700, LEVEL_HEIGHT - 25);
-    walls[28].setPosition(LEVEL_WIDTH - 725, LEVEL_HEIGHT - 25);
-    walls[29].setPosition(LEVEL_WIDTH - 750, LEVEL_HEIGHT - 25);
-    walls[30].setPosition(LEVEL_WIDTH - 550, LEVEL_HEIGHT - 100);
-    walls[31].setPosition(LEVEL_WIDTH - 525, LEVEL_HEIGHT - 100);
-    walls[32].setPosition(LEVEL_WIDTH - 500, LEVEL_HEIGHT - 100);
-    walls[33].setPosition(LEVEL_WIDTH - 475, LEVEL_HEIGHT - 100);
-    walls[34].setPosition(LEVEL_WIDTH - 450, LEVEL_HEIGHT - 100);
-    walls[35].setPosition(LEVEL_WIDTH - 425, LEVEL_HEIGHT - 125);
-    walls[36].setPosition(LEVEL_WIDTH - 400, LEVEL_HEIGHT - 125);
-    walls[37].setPosition(LEVEL_WIDTH - 375, LEVEL_HEIGHT - 125);
-    walls[38].setPosition(LEVEL_WIDTH - 350, LEVEL_HEIGHT - 125);
-    walls[39].setPosition(LEVEL_WIDTH - 325, LEVEL_HEIGHT - 150);
-    walls[40].setPosition(LEVEL_WIDTH - 300, LEVEL_HEIGHT - 175);
-    walls[41].setPosition(LEVEL_WIDTH - 275, LEVEL_HEIGHT - 200);
-    walls[42].setPosition(LEVEL_WIDTH - 250, LEVEL_HEIGHT - 200);
-    walls[43].setPosition(LEVEL_WIDTH - 225, LEVEL_HEIGHT - 200);
-    walls[44].setPosition(LEVEL_WIDTH - 200, LEVEL_HEIGHT - 200);
+    block_sprites[0].setPosition(LEVEL_WIDTH - 25, LEVEL_HEIGHT - 25);
+    block_sprites[1].setPosition(LEVEL_WIDTH - 50, LEVEL_HEIGHT - 25);
+    block_sprites[2].setPosition(LEVEL_WIDTH - 75, LEVEL_HEIGHT - 25);
+    block_sprites[3].setPosition(LEVEL_WIDTH - 100, LEVEL_HEIGHT - 25);
+    block_sprites[4].setPosition(LEVEL_WIDTH - 125, LEVEL_HEIGHT - 25);
+    block_sprites[5].setPosition(LEVEL_WIDTH - 150, LEVEL_HEIGHT - 25);
+    block_sprites[6].setPosition(LEVEL_WIDTH - 175, LEVEL_HEIGHT - 25);
+    block_sprites[7].setPosition(LEVEL_WIDTH - 200, LEVEL_HEIGHT - 25);
+    block_sprites[8].setPosition(LEVEL_WIDTH - 225, LEVEL_HEIGHT - 25);
+    block_sprites[9].setPosition(LEVEL_WIDTH - 250, LEVEL_HEIGHT - 25);
+    block_sprites[10].setPosition(LEVEL_WIDTH - 275, LEVEL_HEIGHT - 25);
+    block_sprites[11].setPosition(LEVEL_WIDTH - 300, LEVEL_HEIGHT - 25);
+    block_sprites[12].setPosition(LEVEL_WIDTH - 325, LEVEL_HEIGHT - 25);
+    block_sprites[13].setPosition(LEVEL_WIDTH - 350, LEVEL_HEIGHT - 25);
+    block_sprites[14].setPosition(LEVEL_WIDTH - 375, LEVEL_HEIGHT - 25);
+    block_sprites[15].setPosition(LEVEL_WIDTH - 400, LEVEL_HEIGHT - 25);
+    block_sprites[16].setPosition(LEVEL_WIDTH - 425, LEVEL_HEIGHT - 25);
+    block_sprites[17].setPosition(LEVEL_WIDTH - 450, LEVEL_HEIGHT - 25);
+    block_sprites[18].setPosition(LEVEL_WIDTH - 475, LEVEL_HEIGHT - 25);
+    block_sprites[19].setPosition(LEVEL_WIDTH - 500, LEVEL_HEIGHT - 25);
+    block_sprites[20].setPosition(LEVEL_WIDTH - 525, LEVEL_HEIGHT - 25);
+    block_sprites[21].setPosition(LEVEL_WIDTH - 550, LEVEL_HEIGHT - 25);
+    block_sprites[22].setPosition(LEVEL_WIDTH - 575, LEVEL_HEIGHT - 25);
+    block_sprites[23].setPosition(LEVEL_WIDTH - 600, LEVEL_HEIGHT - 25);
+    block_sprites[24].setPosition(LEVEL_WIDTH - 625, LEVEL_HEIGHT - 25);
+    block_sprites[25].setPosition(LEVEL_WIDTH - 650, LEVEL_HEIGHT - 25);
+    block_sprites[26].setPosition(LEVEL_WIDTH - 675, LEVEL_HEIGHT - 25);
+    block_sprites[27].setPosition(LEVEL_WIDTH - 700, LEVEL_HEIGHT - 25);
+    block_sprites[28].setPosition(LEVEL_WIDTH - 725, LEVEL_HEIGHT - 25);
+    block_sprites[29].setPosition(LEVEL_WIDTH - 750, LEVEL_HEIGHT - 25);
+    block_sprites[30].setPosition(LEVEL_WIDTH - 550, LEVEL_HEIGHT - 100);
+    block_sprites[31].setPosition(LEVEL_WIDTH - 525, LEVEL_HEIGHT - 100);
+    block_sprites[32].setPosition(LEVEL_WIDTH - 500, LEVEL_HEIGHT - 100);
+    block_sprites[33].setPosition(LEVEL_WIDTH - 475, LEVEL_HEIGHT - 100);
+    block_sprites[34].setPosition(LEVEL_WIDTH - 450, LEVEL_HEIGHT - 100);
+    block_sprites[35].setPosition(LEVEL_WIDTH - 425, LEVEL_HEIGHT - 125);
+    block_sprites[36].setPosition(LEVEL_WIDTH - 400, LEVEL_HEIGHT - 125);
+    block_sprites[37].setPosition(LEVEL_WIDTH - 375, LEVEL_HEIGHT - 125);
+    block_sprites[38].setPosition(LEVEL_WIDTH - 350, LEVEL_HEIGHT - 125);
+    block_sprites[39].setPosition(LEVEL_WIDTH - 325, LEVEL_HEIGHT - 150);
+    block_sprites[40].setPosition(LEVEL_WIDTH - 300, LEVEL_HEIGHT - 175);
+    block_sprites[41].setPosition(LEVEL_WIDTH - 275, LEVEL_HEIGHT - 200);
+    block_sprites[42].setPosition(LEVEL_WIDTH - 250, LEVEL_HEIGHT - 200);
+    block_sprites[43].setPosition(LEVEL_WIDTH - 225, LEVEL_HEIGHT - 200);
+    block_sprites[44].setPosition(LEVEL_WIDTH - 200, LEVEL_HEIGHT - 200);
 
-    platforms[0].setPosition(LEVEL_WIDTH - 600, LEVEL_HEIGHT - 50);
-    platforms[1].setPosition(LEVEL_WIDTH - 575, LEVEL_HEIGHT - 75);
-    platforms[2].setPosition(LEVEL_WIDTH - 150, LEVEL_HEIGHT - 175);
-    platforms[3].setPosition(LEVEL_WIDTH - 125, LEVEL_HEIGHT - 175);
-    platforms[4].setPosition(LEVEL_WIDTH - 150, LEVEL_HEIGHT - 150);
-    platforms[5].setPosition(LEVEL_WIDTH - 125, LEVEL_HEIGHT - 150);
-    platforms[6].setPosition(LEVEL_WIDTH - 150, LEVEL_HEIGHT - 125);
-    platforms[7].setPosition(LEVEL_WIDTH - 125, LEVEL_HEIGHT - 125);
-    platforms[8].setPosition(LEVEL_WIDTH - 150, LEVEL_HEIGHT - 100);
-    platforms[9].setPosition(LEVEL_WIDTH - 125, LEVEL_HEIGHT - 100);
-    platforms[10].setPosition(LEVEL_WIDTH - 150, LEVEL_HEIGHT - 75);
-    platforms[11].setPosition(LEVEL_WIDTH - 125, LEVEL_HEIGHT - 75);
+    platform_sprites[0].setPosition(LEVEL_WIDTH - 600, LEVEL_HEIGHT - 50);
+    platform_sprites[1].setPosition(LEVEL_WIDTH - 575, LEVEL_HEIGHT - 75);
+    platform_sprites[2].setPosition(LEVEL_WIDTH - 150, LEVEL_HEIGHT - 175);
+    platform_sprites[3].setPosition(LEVEL_WIDTH - 125, LEVEL_HEIGHT - 175);
+    platform_sprites[4].setPosition(LEVEL_WIDTH - 150, LEVEL_HEIGHT - 150);
+    platform_sprites[5].setPosition(LEVEL_WIDTH - 125, LEVEL_HEIGHT - 150);
+    platform_sprites[6].setPosition(LEVEL_WIDTH - 150, LEVEL_HEIGHT - 125);
+    platform_sprites[7].setPosition(LEVEL_WIDTH - 125, LEVEL_HEIGHT - 125);
+    platform_sprites[8].setPosition(LEVEL_WIDTH - 150, LEVEL_HEIGHT - 100);
+    platform_sprites[9].setPosition(LEVEL_WIDTH - 125, LEVEL_HEIGHT - 100);
+    platform_sprites[10].setPosition(LEVEL_WIDTH - 150, LEVEL_HEIGHT - 75);
+    platform_sprites[11].setPosition(LEVEL_WIDTH - 125, LEVEL_HEIGHT - 75);
 
     MotionState motion_state;
     motion_state.jump = false;
@@ -200,7 +207,7 @@ int main() {
         player.sprite.setPosition(player_position);
 
         // Render Sprites
-        DrawAllSprites(window, player.sprite, walls, platforms);
+        DrawAllSprites(window, player.sprite, block_sprites, platform_sprites);
 
         // Gravity
         Gravity(&player.sprite, player.motion_speed.accel);
@@ -209,7 +216,7 @@ int main() {
         JumpPhysics(&player.sprite, &player.motion_state, player.motion_speed);
 
         // Sprite Collisions
-        PlayerSpriteCollisions(&player.sprite, walls, platforms,
+        PlayerSpriteCollisions(&player.sprite, block_sprites, platform_sprites,
                                &player.collision_state, player.motion_speed);
     }
 
@@ -236,179 +243,189 @@ sf::Vector2f PlayerBoundary(sf::Vector2f position,
 }
 
 void PlayerSpriteCollisions(sf::Sprite *player_sprite,
-                            std::array<sf::Sprite, 45> walls,
-                            std::array<sf::Sprite, 12> platforms,
+                            std::array<sf::Sprite, 45> block_sprites,
+                            std::array<sf::Sprite, 12> platform_sprites,
                             CollisionState *collision_state,
                             MotionSpeed motion_speed) {
-    PlayerWallCollision(player_sprite, walls[0], collision_state, motion_speed);
-    PlayerWallCollision(player_sprite, walls[1], collision_state, motion_speed);
-    PlayerWallCollision(player_sprite, walls[2], collision_state, motion_speed);
-    PlayerWallCollision(player_sprite, walls[3], collision_state, motion_speed);
-    PlayerWallCollision(player_sprite, walls[4], collision_state, motion_speed);
-    PlayerWallCollision(player_sprite, walls[5], collision_state, motion_speed);
-    PlayerWallCollision(player_sprite, walls[6], collision_state, motion_speed);
-    PlayerWallCollision(player_sprite, walls[7], collision_state, motion_speed);
-    PlayerWallCollision(player_sprite, walls[8], collision_state, motion_speed);
-    PlayerWallCollision(player_sprite, walls[9], collision_state, motion_speed);
-    PlayerWallCollision(player_sprite, walls[10], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[11], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[12], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[13], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[14], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[15], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[16], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[17], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[18], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[19], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[20], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[21], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[22], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[23], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[24], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[25], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[26], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[27], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[28], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[29], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[30], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[31], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[32], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[33], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[34], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[35], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[36], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[37], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[38], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[39], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[40], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[41], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[42], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[43], collision_state,
-                        motion_speed);
-    PlayerWallCollision(player_sprite, walls[44], collision_state,
-                        motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[0], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[1], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[2], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[3], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[4], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[5], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[6], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[7], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[8], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[9], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[10], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[11], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[12], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[13], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[14], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[15], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[16], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[17], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[18], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[19], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[20], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[21], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[22], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[23], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[24], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[25], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[26], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[27], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[28], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[29], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[30], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[31], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[32], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[33], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[34], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[35], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[36], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[37], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[38], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[39], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[40], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[41], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[42], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[43], collision_state,
+                         motion_speed);
+    PlayerBlockCollision(player_sprite, block_sprites[44], collision_state,
+                         motion_speed);
 
-    PlayerPlatformCollision(player_sprite, platforms[0], collision_state,
+    PlayerPlatformCollision(player_sprite, platform_sprites[0], collision_state,
                             motion_speed.accel);
-    PlayerPlatformCollision(player_sprite, platforms[1], collision_state,
+    PlayerPlatformCollision(player_sprite, platform_sprites[1], collision_state,
                             motion_speed.accel);
-    PlayerPlatformCollision(player_sprite, platforms[2], collision_state,
+    PlayerPlatformCollision(player_sprite, platform_sprites[2], collision_state,
                             motion_speed.accel);
-    PlayerPlatformCollision(player_sprite, platforms[3], collision_state,
+    PlayerPlatformCollision(player_sprite, platform_sprites[3], collision_state,
                             motion_speed.accel);
-    PlayerPlatformCollision(player_sprite, platforms[4], collision_state,
+    PlayerPlatformCollision(player_sprite, platform_sprites[4], collision_state,
                             motion_speed.accel);
-    PlayerPlatformCollision(player_sprite, platforms[5], collision_state,
+    PlayerPlatformCollision(player_sprite, platform_sprites[5], collision_state,
                             motion_speed.accel);
-    PlayerPlatformCollision(player_sprite, platforms[6], collision_state,
+    PlayerPlatformCollision(player_sprite, platform_sprites[6], collision_state,
                             motion_speed.accel);
-    PlayerPlatformCollision(player_sprite, platforms[7], collision_state,
+    PlayerPlatformCollision(player_sprite, platform_sprites[7], collision_state,
                             motion_speed.accel);
-    PlayerPlatformCollision(player_sprite, platforms[8], collision_state,
+    PlayerPlatformCollision(player_sprite, platform_sprites[8], collision_state,
                             motion_speed.accel);
-    PlayerPlatformCollision(player_sprite, platforms[9], collision_state,
+    PlayerPlatformCollision(player_sprite, platform_sprites[9], collision_state,
                             motion_speed.accel);
-    PlayerPlatformCollision(player_sprite, platforms[10], collision_state,
-                            motion_speed.accel);
-    PlayerPlatformCollision(player_sprite, platforms[11], collision_state,
-                            motion_speed.accel);
+    PlayerPlatformCollision(player_sprite, platform_sprites[10],
+                            collision_state, motion_speed.accel);
+    PlayerPlatformCollision(player_sprite, platform_sprites[11],
+                            collision_state, motion_speed.accel);
 }
 
 void DrawAllSprites(sf::RenderWindow &window, sf::Sprite &player_sprite,
-                    std::array<sf::Sprite, 45> walls,
-                    std::array<sf::Sprite, 12> platforms) {
+                    std::array<sf::Sprite, 45> block_sprites,
+                    std::array<sf::Sprite, 12> platform_sprites) {
     window.clear(sf::Color(84, 193, 255, 255));
 
-    window.draw(walls[0]);
-    window.draw(walls[1]);
-    window.draw(walls[2]);
-    window.draw(walls[3]);
-    window.draw(walls[4]);
-    window.draw(walls[5]);
-    window.draw(walls[6]);
-    window.draw(walls[7]);
-    window.draw(walls[8]);
-    window.draw(walls[9]);
-    window.draw(walls[10]);
-    window.draw(walls[11]);
-    window.draw(walls[12]);
-    window.draw(walls[13]);
-    window.draw(walls[14]);
-    window.draw(walls[15]);
-    window.draw(walls[16]);
-    window.draw(walls[17]);
-    window.draw(walls[18]);
-    window.draw(walls[19]);
-    window.draw(walls[20]);
-    window.draw(walls[21]);
-    window.draw(walls[22]);
-    window.draw(walls[23]);
-    window.draw(walls[24]);
-    window.draw(walls[25]);
-    window.draw(walls[26]);
-    window.draw(walls[27]);
-    window.draw(walls[28]);
-    window.draw(walls[29]);
-    window.draw(walls[30]);
-    window.draw(walls[31]);
-    window.draw(walls[32]);
-    window.draw(walls[33]);
-    window.draw(walls[34]);
-    window.draw(walls[35]);
-    window.draw(walls[36]);
-    window.draw(walls[37]);
-    window.draw(walls[38]);
-    window.draw(walls[39]);
-    window.draw(walls[40]);
-    window.draw(walls[41]);
-    window.draw(walls[42]);
-    window.draw(walls[43]);
-    window.draw(walls[44]);
-    window.draw(platforms[0]);
-    window.draw(platforms[1]);
-    window.draw(platforms[2]);
-    window.draw(platforms[3]);
-    window.draw(platforms[4]);
-    window.draw(platforms[5]);
-    window.draw(platforms[6]);
-    window.draw(platforms[7]);
-    window.draw(platforms[8]);
-    window.draw(platforms[9]);
-    window.draw(platforms[10]);
-    window.draw(platforms[11]);
+    window.draw(block_sprites[0]);
+    window.draw(block_sprites[1]);
+    window.draw(block_sprites[2]);
+    window.draw(block_sprites[3]);
+    window.draw(block_sprites[4]);
+    window.draw(block_sprites[5]);
+    window.draw(block_sprites[6]);
+    window.draw(block_sprites[7]);
+    window.draw(block_sprites[8]);
+    window.draw(block_sprites[9]);
+    window.draw(block_sprites[10]);
+    window.draw(block_sprites[11]);
+    window.draw(block_sprites[12]);
+    window.draw(block_sprites[13]);
+    window.draw(block_sprites[14]);
+    window.draw(block_sprites[15]);
+    window.draw(block_sprites[16]);
+    window.draw(block_sprites[17]);
+    window.draw(block_sprites[18]);
+    window.draw(block_sprites[19]);
+    window.draw(block_sprites[20]);
+    window.draw(block_sprites[21]);
+    window.draw(block_sprites[22]);
+    window.draw(block_sprites[23]);
+    window.draw(block_sprites[24]);
+    window.draw(block_sprites[25]);
+    window.draw(block_sprites[26]);
+    window.draw(block_sprites[27]);
+    window.draw(block_sprites[28]);
+    window.draw(block_sprites[29]);
+    window.draw(block_sprites[30]);
+    window.draw(block_sprites[31]);
+    window.draw(block_sprites[32]);
+    window.draw(block_sprites[33]);
+    window.draw(block_sprites[34]);
+    window.draw(block_sprites[35]);
+    window.draw(block_sprites[36]);
+    window.draw(block_sprites[37]);
+    window.draw(block_sprites[38]);
+    window.draw(block_sprites[39]);
+    window.draw(block_sprites[40]);
+    window.draw(block_sprites[41]);
+    window.draw(block_sprites[42]);
+    window.draw(block_sprites[43]);
+    window.draw(block_sprites[44]);
+    window.draw(platform_sprites[0]);
+    window.draw(platform_sprites[1]);
+    window.draw(platform_sprites[2]);
+    window.draw(platform_sprites[3]);
+    window.draw(platform_sprites[4]);
+    window.draw(platform_sprites[5]);
+    window.draw(platform_sprites[6]);
+    window.draw(platform_sprites[7]);
+    window.draw(platform_sprites[8]);
+    window.draw(platform_sprites[9]);
+    window.draw(platform_sprites[10]);
+    window.draw(platform_sprites[11]);
     window.draw(player_sprite);
 
     window.display();


### PR DESCRIPTION
Renamed the variables containing wall to block.

## Extras
- Renamed the sprite variables to contain the word sprite.
- Fixed a bug for the bottom collision of the player and block collision